### PR TITLE
rapidxml_ns_print: Added function declarations to solve error with clang/llvm compiler

### DIFF
--- a/rapidxml_ns_print.hpp
+++ b/rapidxml_ns_print.hpp
@@ -101,7 +101,18 @@ namespace rapidxml_ns
 
         ///////////////////////////////////////////////////////////////////////////
         // Internal printing operations
-    
+   
+        // Printing function declarations (fix for clang bug in gcc and others: http://sourceforge.net/p/rapidxml/bugs/16/)
+
+        template<class OutIt, class Ch> inline OutIt print_children(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+        template<class OutIt, class Ch> inline OutIt print_element_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+        template<class OutIt, class Ch> inline OutIt print_data_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+        template<class OutIt, class Ch> inline OutIt print_cdata_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+        template<class OutIt, class Ch> inline OutIt print_declaration_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+        template<class OutIt, class Ch> inline OutIt print_comment_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+        template<class OutIt, class Ch> inline OutIt print_doctype_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+        template<class OutIt, class Ch> inline OutIt print_pi_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+ 
         // Print node
         template<class OutIt, class Ch>
         inline OutIt print_node(OutIt out, const xml_node<Ch> *node, int flags, int indent)


### PR DESCRIPTION
Added printing function declarations to `rapidxml_ns_print.hpp` in order to fix issue with function visibility (with clang compiler).

Refer to: https://sourceforge.net/p/rapidxml/bugs/16/

Also refer to rapidxml fix: https://github.com/dwd/rapidxml/commit/69bed42b09ad37fb92fdad22da9f84dd0abd2055

Note: I found this problem when I was trying to save a simple svg file with svgpp. The next step would be to update `rapidxml_ns` in `svgpp/third_party/rapidxml_ns/`. Maybe even add a test.